### PR TITLE
agent: guard Lambda packaging against missing subpackages

### DIFF
--- a/agent/deploy.sh
+++ b/agent/deploy.sh
@@ -63,6 +63,24 @@ for fn in research draft verify notify publish approve ingest chart upload alarm
         echo "   Fix: ensure you run 'zip' from inside the Lambda directory."
         exit 1
       fi
+
+      # Package-completeness check: every source .py module must be present in the
+      # zip. Catches missing subpackages (e.g. chart/renderers) that import fine
+      # from source but get left out of the artifact, surfacing only at runtime as
+      # Runtime.ImportModuleError ("No module named 'renderers'") in Lambda.
+      zip_contents="$(unzip -l "${fn}.zip" | awk '{print $4}')"
+      missing=""
+      while IFS= read -r src; do
+        rel="${src#"${fn}/"}"
+        if ! printf '%s\n' "$zip_contents" | grep -qx "$rel"; then
+          missing="${missing} ${rel}"
+        fi
+      done < <(find "$fn" -name '*.py' -not -path '*/__pycache__/*' -not -path '*/.ruff_cache/*')
+      if [ -n "$missing" ]; then
+        echo "!! INCOMPLETE PACKAGE in ${fn}.zip — source modules missing from zip:${missing}"
+        echo "   Fix: ensure subpackages are included (run 'zip -r' from inside ${fn}/)."
+        exit 1
+      fi
     fi
   fi
 done


### PR DESCRIPTION
## Summary
On 2026-06-04 the `blog-agent` pipeline failed at the `GenerateCharts` step with `Runtime.ImportModuleError: No module named 'renderers'` — a deployed `chart` zip was missing its `renderers/` subpackage. `agent/deploy.sh` already validated that `index.py` sits at the zip root, but nothing checked that subpackages made it into the artifact, so the gap surfaced only at runtime in Lambda.

This adds a **package-completeness check** to the existing post-zip validation in `agent/deploy.sh`: after building each `${fn}.zip`, assert every source `.py` module is present in the artifact, aborting the deploy with the list of missing modules.

```sh
zip_contents="$(unzip -l "${fn}.zip" | awk '{print $4}')"
for each src in `find "$fn" -name '*.py'` (excl __pycache__/.ruff_cache):
    rel = src without "${fn}/" prefix
    if rel not in zip_contents: missing += rel
if missing: echo "!! INCOMPLETE PACKAGE in ${fn}.zip — ... :${missing}"; exit 1
```

Note this complements the existing CI suite (`agent/tests/test_handlers.py` imports every handler + `chart/renderers` from **source**); that can't catch a packaging drop because source always contains the module. This check operates on the **built artifact**, which is where the failure actually occurred.

Verified locally against the real `chart/` dir: a complete `zip -qr` passes; a zip built with `-x 'renderers/*'` fails listing exactly the 11 missing `renderers/*.py` modules. `bash -n agent/deploy.sh` passes.

Link to Devin session: https://app.devin.ai/sessions/c07c24d931aa434bbe8f4bde1a42f78c
Requested by: @kzaky