### PR TITLE
infra: scope CodeBuild webhook to master pushes (stop PR-build alarm noise)

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -45,6 +45,19 @@ These resources don't support CFN import and are managed outside the stacks:
 
 Templates for these resources are preserved as comments in `template.yaml` for documentation.
 
+### CodeBuild webhook scoping
+
+The CodeBuild webhook ships with empty `filterGroups`, so it builds every push and
+pull-request event on every branch. PR-branch build failures then trip the
+`khaledzaky-codebuild-failure` alarm even though `master` deploys are healthy, and
+they duplicate the GitHub Actions PR checks (`.github/workflows/ci.yml`). Scope the
+webhook to `master` pushes only (matching the `FilterGroups` documented in
+`template.yaml`):
+
+```bash
+./scripts/set-codebuild-webhook-filter.sh   # defaults to project khaledzaky_com
+```
+
 ## Security
 
 - No AWS account IDs, emails, or secrets in template defaults

--- a/infra/scripts/set-codebuild-webhook-filter.sh
+++ b/infra/scripts/set-codebuild-webhook-filter.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Scope the CodeBuild webhook to PUSH events on master only.
+#
+# Why: the khaledzaky_com CodeBuild project's webhook ships with empty
+# filterGroups, so it builds *every* push and pull-request event on *any*
+# branch. Any PR-branch build failure then trips the `khaledzaky-codebuild-
+# failure` alarm even though production (master) deploys are fine. GitHub
+# Actions (.github/workflows/ci.yml) already validates pull requests, so the
+# CodeBuild project only needs to run on merges to master (the deploy).
+#
+# This applies the same FilterGroups documented in infra/template.yaml's
+# CodeBuildProject reference block. It is idempotent — re-running just
+# re-applies the same filter.
+#
+# Usage: ./set-codebuild-webhook-filter.sh [project-name]
+set -euo pipefail
+
+PROJECT="${1:-khaledzaky_com}"
+REGION="${AWS_DEFAULT_REGION:-us-east-1}"
+
+echo ">> Scoping webhook for CodeBuild project '${PROJECT}' (region ${REGION}) to PUSH on master..."
+aws codebuild update-webhook \
+  --project-name "${PROJECT}" \
+  --region "${REGION}" \
+  --filter-groups '[[{"type":"EVENT","pattern":"PUSH"},{"type":"HEAD_REF","pattern":"^refs/heads/master$"}]]' \
+  --no-cli-pager
+
+echo ">> Done. Current filter groups:"
+aws codebuild batch-get-projects \
+  --names "${PROJECT}" \
+  --region "${REGION}" \
+  --query 'projects[0].webhook.filterGroups' \
+  --output json


### PR DESCRIPTION
## Summary
The live `khaledzaky_com` CodeBuild webhook has **empty `filterGroups`**, so it builds every push and PR event on every branch. PR-branch build failures (e.g. the pre-Node-22 `pr/59` commits and the bare `pr/60` bump) then trip the `khaledzaky-codebuild-failure` alarm even though `master`/production deploys are fine — and they duplicate the GitHub Actions PR checks (`.github/workflows/ci.yml`). CodeBuild only needs to run on merges to `master` (the deploy).

This adds `infra/scripts/set-codebuild-webhook-filter.sh`, which applies the same `FilterGroups` already documented (but not live) in `template.yaml`'s commented `CodeBuildProject` block:

```
FilterGroups:
  - - Type: EVENT
      Pattern: PUSH
    - Type: HEAD_REF
      Pattern: ^refs/heads/master$
```

i.e. `aws codebuild update-webhook --project-name khaledzaky_com --filter-groups '[[{"type":"EVENT","pattern":"PUSH"},{"type":"HEAD_REF","pattern":"^refs/heads/master$"}]]'`. Idempotent; prints the resulting filter. Also documents it in `infra/README.md`.

## Context
The CodeBuild project, its webhook, and the `khaledzaky-codebuild-failure` alarm are all managed **outside CloudFormation** (only `khaledzaky-site-down` is in the `khaledzaky-infra` stack), so this is delivered as a CLI helper script rather than a template change — matching the existing "Resources Not in CloudFormation" pattern.

## Not done in this PR
The script was **not** executed against live infra (it changes build behavior — PRs would stop building in CodeBuild). Run `./infra/scripts/set-codebuild-webhook-filter.sh` (or say the word and I'll run it) to apply. Validated locally: `bash -n` passes, the filter JSON is valid, and the installed AWS CLI accepts `update-webhook --filter-groups`.

Link to Devin session: https://app.devin.ai/sessions/c07c24d931aa434bbe8f4bde1a42f78c
Requested by: @kzaky