### PR TITLE
buildspec: edge-cache HTML (s-maxage) to fix low CloudFront cache-hit rate

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -33,11 +33,16 @@ phases:
           echo "ERROR: dist/index.html missing — aborting deploy to prevent deleting live site"
           exit 1
         fi
-      - "aws s3 sync dist/ s3://khaledzaky.com --delete --cache-control 'public, max-age=0, must-revalidate' --exclude '_astro/*' --exclude 'img/*' --exclude 'og/*'"
+      # HTML/feeds: browsers revalidate (max-age=0) but CloudFront caches at the
+      # edge (s-maxage). Every deploy invalidates /* below, so the edge cache is
+      # purged on each release and never serves stale content between deploys.
+      - "aws s3 sync dist/ s3://khaledzaky.com --delete --cache-control 'public, max-age=0, s-maxage=86400, must-revalidate' --exclude '_astro/*' --exclude 'img/*' --exclude 'og/*'"
       - "aws s3 sync dist/_astro/ s3://khaledzaky.com/_astro/ --delete --cache-control 'public, max-age=31536000, immutable'"
       - "aws s3 sync dist/img/ s3://khaledzaky.com/img/ --cache-control 'public, max-age=86400'"
       - "aws s3 sync dist/og/ s3://khaledzaky.com/og/ --cache-control 'public, max-age=86400'"
       - echo "***************************************"
       - echo "**** Invalidate Cloudfront cache ******"
       - echo "***************************************"
-      - aws cloudfront create-invalidation --distribution-id $DIST_ID --paths "/" "/blog/*" "/blog/category/*" "/about/" "/work/" "/drop/"
+      # Invalidate everything: HTML/feeds now carry an edge TTL (s-maxage), so a
+      # full invalidation is required to guarantee fresh content after each deploy.
+      - aws cloudfront create-invalidation --distribution-id $DIST_ID --paths "/*"


### PR DESCRIPTION
## Summary
Root-cause fix for the `khaledzaky-cloudfront-low-cache-hit-rate` alarm emails. HTML/feeds were uploaded to S3 with `cache-control: public, max-age=0, must-revalidate`, which forces CloudFront to revalidate the origin on **every** request — so pages are never served as a fresh edge cache hit (`x-cache: Miss`/`RefreshHit`). Hashed assets (`/_astro/*`, `immutable`) hit fine, but all HTML + crawler traffic missed, holding `CacheHitRate` at a **7-day median of ~38%** (range 16.7–47%, 24/168 hrs < 30%) at **~1,900–2,600 req/hr**.

Fix: let CloudFront cache HTML/feeds at the edge via `s-maxage`, while browsers still always revalidate via `max-age=0`.

```diff
- --cache-control 'public, max-age=0, must-revalidate'      # HTML/feeds sync
+ --cache-control 'public, max-age=0, s-maxage=86400, must-revalidate'

- create-invalidation --paths "/" "/blog/*" "/blog/category/*" "/about/" "/work/" "/drop/"
+ create-invalidation --paths "/*"
```

## Why this is safe
- `max-age=0` → browsers keep revalidating, so users never see stale HTML in their own cache.
- `s-maxage=86400` → CloudFront serves cached HTML at the edge (the hits we're missing today). The managed **CachingOptimized** policy honors `s-maxage` and doesn't fragment the cache key on query strings/cookies.
- The deploy already invalidates on every release; broadening it to `/*` guarantees the edge-cached HTML/feeds are purged immediately when content changes (the agent publishes new posts via a deploy too). `/*` counts as a single invalidation path (well within the 1,000/month free tier at ~15 deploys/mo).

## Impact
Asset hits + newly-cached HTML should push the blended `CacheHitRate` from ~38% toward the 80–90%+ typical of a static CDN, which both quiets the alarm and reduces origin/transfer load. Takes effect on the next deploy (merge to `master`). After it deploys I can verify `x-cache: Hit` on HTML and watch the metric recover.

_Note: the alarm itself is CLI-managed (not in CloudFormation); this PR fixes the underlying cause rather than the threshold._

Link to Devin session: https://app.devin.ai/sessions/c07c24d931aa434bbe8f4bde1a42f78c
Requested by: @kzaky